### PR TITLE
Add admin API and wire admin panel to remote MySQL

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,13 @@
+# Frontend
+VITE_API_BASE_URL=http://localhost:8000/api/v1
+
+# Admin credentials
+ADMIN_EMAIL=admin@gglusa.us
+ADMIN_PASSWORD=Admin@12345
+
+# Remote MySQL
+MYSQL_HOST=srv1900.hstgr.io
+MYSQL_PORT=3306
+MYSQL_DATABASE=u546576758_ggl_usa
+MYSQL_USER=u546576758_karthik
+MYSQL_PASSWORD=Admin@2026@#

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "dev:server": "node server.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -61,7 +62,11 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.3",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.21.1",
+    "mysql2": "^3.11.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,79 @@
+import cors from "cors";
+import dotenv from "dotenv";
+import express from "express";
+import mysql from "mysql2/promise";
+
+dotenv.config();
+
+const app = express();
+const port = Number(process.env.PORT ?? 8000);
+
+app.use(cors());
+app.use(express.json());
+
+const adminEmail = process.env.ADMIN_EMAIL ?? "admin@gglusa.us";
+const adminPassword = process.env.ADMIN_PASSWORD ?? "Admin@12345";
+
+const pool = mysql.createPool({
+  host: process.env.MYSQL_HOST,
+  port: Number(process.env.MYSQL_PORT ?? 3306),
+  user: process.env.MYSQL_USER,
+  password: process.env.MYSQL_PASSWORD,
+  database: process.env.MYSQL_DATABASE,
+  waitForConnections: true,
+  connectionLimit: 10,
+});
+
+app.post("/api/v1/admin/login", async (req, res) => {
+  const { email, password } = req.body ?? {};
+
+  if (email !== adminEmail || password !== adminPassword) {
+    return res.status(401).json({ message: "Invalid admin credentials" });
+  }
+
+  try {
+    const conn = await pool.getConnection();
+    await conn.ping();
+    conn.release();
+
+    return res.json({
+      authenticated: true,
+      email,
+      connected: true,
+      message: "Login successful and MySQL connection verified",
+    });
+  } catch (error) {
+    return res.status(500).json({
+      authenticated: false,
+      connected: false,
+      message: "Login passed but failed to connect to MySQL",
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+});
+
+app.get("/api/v1/admin/summary", async (_req, res) => {
+  try {
+    const [rows] = await pool.query("SELECT DATABASE() AS dbName, NOW() AS serverTime");
+    const summary = Array.isArray(rows) ? rows[0] : null;
+
+    return res.json({
+      status: "ok",
+      dbName: summary?.dbName ?? process.env.MYSQL_DATABASE,
+      serverTime: summary?.serverTime,
+    });
+  } catch (error) {
+    return res.status(500).json({
+      status: "error",
+      message: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+});
+
+app.get("/api/v1/health", async (_req, res) => {
+  res.json({ status: "ok" });
+});
+
+app.listen(port, () => {
+  console.log(`Admin API running on http://localhost:${port}`);
+});

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -1,32 +1,46 @@
-import { FormEvent, useMemo, useState } from "react";
+import { FormEvent, useState } from "react";
 
-import { ADMIN_AUTH_STORAGE_KEY, defaultAdminCredentials, nonProductionSecurityWarning } from "@/config/adminAuth";
+import { apiFetch } from "@/api/client";
+import { ADMIN_AUTH_STORAGE_KEY, nonProductionSecurityWarning } from "@/config/adminAuth";
 import { AdminPanel } from "./admin/AdminPanel";
+
+type LoginResponse = {
+  authenticated: boolean;
+  connected: boolean;
+  message: string;
+  email: string;
+};
 
 export default function AdminPage() {
   const [isAuthenticated, setIsAuthenticated] = useState(() => localStorage.getItem(ADMIN_AUTH_STORAGE_KEY) === "true");
-  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
-
-  const creds = useMemo(() => defaultAdminCredentials, []);
 
   const login = async (event: FormEvent) => {
     event.preventDefault();
     setLoading(true);
     setError("");
 
-    const localValid = username === creds.username && password === creds.password;
+    try {
+      const response = await apiFetch<LoginResponse>("/admin/login", {
+        method: "POST",
+        body: JSON.stringify({ email, password }),
+      });
 
-    if (localValid) {
+      if (!response.authenticated || !response.connected) {
+        setError(response.message || "Unable to authenticate");
+        return;
+      }
+
       localStorage.setItem(ADMIN_AUTH_STORAGE_KEY, "true");
       setIsAuthenticated(true);
-    } else {
-      setError("Invalid credentials.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Login failed");
+    } finally {
+      setLoading(false);
     }
-
-    setLoading(false);
   };
 
   const logout = () => {
@@ -43,7 +57,7 @@ export default function AdminPage() {
       <form className="w-full max-w-md space-y-4 rounded-xl border bg-white p-6" onSubmit={login}>
         <h1 className="text-2xl font-semibold">Admin Login</h1>
         <p className="rounded border border-amber-400 bg-amber-100 p-3 text-sm text-amber-900">{nonProductionSecurityWarning}</p>
-        <input className="w-full rounded border px-3 py-2" placeholder="Username" value={username} onChange={(e) => setUsername(e.target.value)} />
+        <input className="w-full rounded border px-3 py-2" placeholder="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
         <input className="w-full rounded border px-3 py-2" type="password" placeholder="Password" value={password} onChange={(e) => setPassword(e.target.value)} />
         {error ? <p className="text-sm text-red-600">{error}</p> : null}
         <button disabled={loading} className="w-full rounded bg-slate-900 px-4 py-2 text-white">

--- a/src/pages/admin/AdminPanel.tsx
+++ b/src/pages/admin/AdminPanel.tsx
@@ -1,9 +1,17 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
+import { apiFetch } from "@/api/client";
 import { nonProductionSecurityWarning } from "@/config/adminAuth";
 
 type Module = "seo" | "content" | "pages" | "headers" | "locations";
 type DummyRecord = Record<string, string | number | boolean>;
+
+type SummaryResponse = {
+  status: string;
+  dbName?: string;
+  serverTime?: string;
+  message?: string;
+};
 
 const modules: Module[] = ["seo", "content", "pages", "headers", "locations"];
 
@@ -34,6 +42,15 @@ const seedData: Record<Module, DummyRecord[]> = {
 export function AdminPanel({ onLogout }: { onLogout: () => void }) {
   const [active, setActive] = useState<Module>("seo");
   const [search, setSearch] = useState("");
+  const [summary, setSummary] = useState<SummaryResponse | null>(null);
+
+  useEffect(() => {
+    apiFetch<SummaryResponse>("/admin/summary")
+      .then(setSummary)
+      .catch((error) => {
+        setSummary({ status: "error", message: error instanceof Error ? error.message : "Failed to fetch summary" });
+      });
+  }, []);
 
   const counters = useMemo(
     () => ({
@@ -52,9 +69,21 @@ export function AdminPanel({ onLogout }: { onLogout: () => void }) {
   return (
     <div className="min-h-screen bg-slate-50 p-4 md:p-6">
       <p className="mb-3 rounded border border-amber-400 bg-amber-100 p-3 text-sm text-amber-900">{nonProductionSecurityWarning}</p>
+      <div className="mb-4 rounded-xl border bg-white p-4 text-sm">
+        <p className="font-semibold">Remote MySQL status</p>
+        {summary?.status === "ok" ? (
+          <p>
+            Connected to <span className="font-semibold">{summary.dbName}</span>
+            {summary.serverTime ? ` · Server time: ${summary.serverTime}` : ""}
+          </p>
+        ) : (
+          <p className="text-red-600">{summary?.message ?? "Checking connection..."}</p>
+        )}
+      </div>
+
       <div className="grid gap-4 md:grid-cols-[220px_1fr]">
         <aside className="rounded-xl border bg-white p-4">
-          <h2 className="mb-3 font-semibold">Admin (Static)</h2>
+          <h2 className="mb-3 font-semibold">Admin Panel</h2>
           <button className="mb-3 rounded border px-3 py-1 text-sm" onClick={onLogout}>Logout</button>
           <div className="space-y-2">
             {modules.map((m) => (
@@ -83,7 +112,7 @@ export function AdminPanel({ onLogout }: { onLogout: () => void }) {
               placeholder="Search/filter records"
               className="w-full max-w-sm rounded border px-3 py-2"
             />
-            <span className="text-sm text-muted-foreground">Direct static mode (no backend logic).</span>
+            <span className="text-sm text-muted-foreground">Dummy records mode with backend MySQL connectivity.</span>
           </div>
 
           <div>


### PR DESCRIPTION
### Motivation
- Provide a minimal backend admin API to validate admin login and verify connectivity to the supplied remote MySQL instance so the admin UI can surface connection status.

### Description
- Add `server.js` implementing `POST /api/v1/admin/login`, `GET /api/v1/admin/summary`, and a health endpoint using `mysql2` to check DB connectivity.
- Add `.env` and `.env.example` with `ADMIN_EMAIL`, `ADMIN_PASSWORD`, `VITE_API_BASE_URL` and the remote MySQL variables supplied by the user.
- Update `src/pages/Admin.tsx` to authenticate via the backend `POST /admin/login` and persist admin auth to `localStorage` instead of using client-only credentials.
- Update `src/pages/admin/AdminPanel.tsx` to call `GET /admin/summary` and display the remote MySQL connection summary, and add a `dev:server` script plus backend dependencies to `package.json`.

### Testing
- Ran `npm run build` which completed successfully and produced the production `dist` bundle.
- Ran `npm run lint` which failed due to pre-existing TypeScript/ESLint errors in unrelated files, so lint issues were not introduced by this PR.
- Attempted `npm install` but it failed with a `403 Forbidden` from the npm registry, so backend dependencies could not be installed and `node server.js` could not be started in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d27e0b8a8c83339e5e6742c766ca22)