### PR TITLE
Add MySQL-backed SEO API, admin UI integration, client base fix, and Vercel rewrite

### DIFF
--- a/api/_lib/mysql.js
+++ b/api/_lib/mysql.js
@@ -1,0 +1,24 @@
+import mysql from "mysql2/promise";
+
+const pool = mysql.createPool({
+  host: process.env.MYSQL_HOST,
+  port: Number(process.env.MYSQL_PORT ?? 3306),
+  user: process.env.MYSQL_USER,
+  password: process.env.MYSQL_PASSWORD,
+  database: process.env.MYSQL_DATABASE,
+  waitForConnections: true,
+  connectionLimit: 10,
+});
+
+export function parseJsonField(value) {
+  if (!value) return {};
+  if (typeof value === "object") return value;
+
+  try {
+    return JSON.parse(value);
+  } catch {
+    return {};
+  }
+}
+
+export { pool };

--- a/api/v1/seo.js
+++ b/api/v1/seo.js
@@ -1,0 +1,75 @@
+import { parseJsonField, pool } from "../_lib/mysql.js";
+
+export default async function handler(req, res) {
+  try {
+    if (req.method === "GET") {
+      const page = Number(req.query.page ?? 1);
+      const pageSize = Number(req.query.page_size ?? 20);
+      const q = String(req.query.q ?? "").trim();
+      const offset = (Math.max(page, 1) - 1) * Math.max(pageSize, 1);
+
+      const whereSql = q ? "WHERE path LIKE ? OR title LIKE ? OR description LIKE ? OR keywords LIKE ?" : "";
+      const whereParams = q ? [`%${q}%`, `%${q}%`, `%${q}%`, `%${q}%`] : [];
+
+      const [rows] = await pool.query(
+        `SELECT id, path, title, description, keywords, extra_meta_json, created_at, updated_at FROM seo_records ${whereSql} ORDER BY id DESC LIMIT ? OFFSET ?`,
+        [...whereParams, Math.max(pageSize, 1), offset],
+      );
+
+      const [countRows] = await pool.query(`SELECT COUNT(*) as total FROM seo_records ${whereSql}`, whereParams);
+
+      const items = Array.isArray(rows)
+        ? rows.map((row) => ({
+            ...row,
+            extra_meta_json: parseJsonField(row.extra_meta_json),
+          }))
+        : [];
+
+      const total = Array.isArray(countRows) ? Number(countRows[0]?.total ?? 0) : 0;
+      return res.status(200).json({ items, page: Math.max(page, 1), page_size: Math.max(pageSize, 1), total });
+    }
+
+    if (req.method === "POST") {
+      const { path, title, description, keywords, extra_meta_json } = req.body ?? {};
+      if (!path || !title || !description || !keywords) {
+        return res.status(400).json({ message: "path, title, description, keywords are required" });
+      }
+
+      const [existingRows] = await pool.query("SELECT id FROM seo_records WHERE path = ? LIMIT 1", [path]);
+      const existingId = Array.isArray(existingRows) && existingRows[0] ? Number(existingRows[0].id) : null;
+
+      if (existingId) {
+        await pool.query(
+          "UPDATE seo_records SET title = ?, description = ?, keywords = ?, extra_meta_json = ? WHERE id = ?",
+          [title, description, keywords, JSON.stringify(extra_meta_json ?? {}), existingId],
+        );
+        const [updatedRows] = await pool.query(
+          "SELECT id, path, title, description, keywords, extra_meta_json, created_at, updated_at FROM seo_records WHERE id = ?",
+          [existingId],
+        );
+        const record = Array.isArray(updatedRows) ? updatedRows[0] : null;
+        return res.status(200).json({ ...record, extra_meta_json: parseJsonField(record?.extra_meta_json) });
+      }
+
+      const [insertResult] = await pool.query(
+        "INSERT INTO seo_records (path, title, description, keywords, extra_meta_json) VALUES (?, ?, ?, ?, ?)",
+        [path, title, description, keywords, JSON.stringify(extra_meta_json ?? {})],
+      );
+
+      const insertedId = Number(insertResult?.insertId);
+      const [insertedRows] = await pool.query(
+        "SELECT id, path, title, description, keywords, extra_meta_json, created_at, updated_at FROM seo_records WHERE id = ?",
+        [insertedId],
+      );
+
+      const record = Array.isArray(insertedRows) ? insertedRows[0] : null;
+      return res.status(201).json({ ...record, extra_meta_json: parseJsonField(record?.extra_meta_json) });
+    }
+
+    return res.status(405).json({ message: "Method not allowed" });
+  } catch (error) {
+    return res.status(500).json({
+      message: error instanceof Error ? error.message : "Failed to handle seo request",
+    });
+  }
+}

--- a/api/v1/seo/[id].js
+++ b/api/v1/seo/[id].js
@@ -1,0 +1,48 @@
+import { parseJsonField, pool } from "../../_lib/mysql.js";
+
+export default async function handler(req, res) {
+  try {
+    const id = Number(req.query.id);
+
+    if (!Number.isFinite(id) || id <= 0) {
+      return res.status(400).json({ message: "Invalid SEO id" });
+    }
+
+    if (req.method === "PUT") {
+      const { path, title, description, keywords, extra_meta_json } = req.body ?? {};
+
+      const [result] = await pool.query(
+        "UPDATE seo_records SET path = ?, title = ?, description = ?, keywords = ?, extra_meta_json = ? WHERE id = ?",
+        [path, title, description, keywords, JSON.stringify(extra_meta_json ?? {}), id],
+      );
+
+      if (!result?.affectedRows) {
+        return res.status(404).json({ message: "SEO record not found" });
+      }
+
+      const [rows] = await pool.query(
+        "SELECT id, path, title, description, keywords, extra_meta_json, created_at, updated_at FROM seo_records WHERE id = ?",
+        [id],
+      );
+
+      const record = Array.isArray(rows) ? rows[0] : null;
+      return res.status(200).json({ ...record, extra_meta_json: parseJsonField(record?.extra_meta_json) });
+    }
+
+    if (req.method === "DELETE") {
+      const [result] = await pool.query("DELETE FROM seo_records WHERE id = ?", [id]);
+
+      if (!result?.affectedRows) {
+        return res.status(404).json({ message: "SEO record not found" });
+      }
+
+      return res.status(200).json({ ok: true });
+    }
+
+    return res.status(405).json({ message: "Method not allowed" });
+  } catch (error) {
+    return res.status(500).json({
+      message: error instanceof Error ? error.message : "Failed to handle seo id request",
+    });
+  }
+}

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,4 +1,4 @@
-const API_BASE = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000/api/v1";
+const API_BASE = (import.meta.env.VITE_API_BASE_URL ?? "/api/v1").replace(/\/$/, "");
 
 export async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch(`${API_BASE}${path}`, {

--- a/src/pages/admin/AdminPanel.tsx
+++ b/src/pages/admin/AdminPanel.tsx
@@ -62,7 +62,7 @@ const seedData: Record<Exclude<Module, "content">, DummyRecord[]> = {
   ],
 };
 
-const initialSeoForm: SeoFormState = {
+const defaultSeoFormState: SeoFormState = {
   path: "/",
   title: "",
   description: "",
@@ -80,26 +80,28 @@ export function AdminPanel({ onLogout }: { onLogout: () => void }) {
   const [active, setActive] = useState<Module>("content");
   const [search, setSearch] = useState("");
   const [form, setForm] = useState<ContentFormState>(initialForm);
-  const [seoForm, setSeoForm] = useState<SeoFormState>(initialSeoForm);
+  const [seoFormState, setSeoFormState] = useState<SeoFormState>(defaultSeoFormState);
   const [editingId, setEditingId] = useState<number | null>(null);
   const [formError, setFormError] = useState("");
-  const [seoError, setSeoError] = useState("");
-  const [editingSeoId, setEditingSeoId] = useState<number | null>(null);
+  const [seoFormError, setSeoFormError] = useState("");
+  const [editingSeoRecordId, setEditingSeoRecordId] = useState<number | null>(null);
 
   const { pages, headers, locations, seo, content } = useAdminCollections(search);
-  const seoAll = useQuery({
+  const seoRecordsQuery = useQuery({
     queryKey: ["seo", "all-records"],
     queryFn: () => apiFetch<{ items: SeoRecord[]; total: number }>("/seo?page=1&page_size=500"),
     refetchInterval: 10000,
   });
-  const seoItems = seoAll.data?.items?.length ? seoAll.data.items : (seo.data?.items ?? []);
+  const seoItems = seoRecordsQuery.data?.items?.length ? seoRecordsQuery.data.items : (seo.data?.items ?? []);
+  const seoLoading = seoRecordsQuery.isLoading || seo.isLoading;
+  const seoLoadError = (seoRecordsQuery.error as Error | null)?.message || (seo.error as Error | null)?.message || "";
 
-  const createContent = useCreateRecord("content");
-  const deleteContent = useDeleteRecord("content");
-  const updateContent = useUpdateRecord("content");
-  const upsertSeo = useCreateRecord("seo");
-  const updateSeo = useUpdateRecord("seo");
-  const deleteSeo = useDeleteRecord("seo");
+  const createContentRecord = useCreateRecord("content");
+  const deleteContentRecord = useDeleteRecord("content");
+  const updateContentRecord = useUpdateRecord("content");
+  const createSeoRecord = useCreateRecord("seo");
+  const updateSeoRecord = useUpdateRecord("seo");
+  const deleteSeoRecord = useDeleteRecord("seo");
 
 
   const counters = useMemo(
@@ -108,9 +110,9 @@ export function AdminPanel({ onLogout }: { onLogout: () => void }) {
       headers: headers.data?.total ?? seedData.headers.length,
       locations: locations.data?.total ?? seedData.locations.length,
       content: content.data?.total ?? 0,
-      seo: seoAll.data?.total ?? seo.data?.total ?? seoItems.length ?? seedData.seo.length,
+      seo: seoRecordsQuery.data?.total ?? seo.data?.total ?? seoItems.length ?? seedData.seo.length,
     }),
-    [content.data?.total, headers.data?.total, locations.data?.total, pages.data?.total, seo.data?.total, seoAll.data?.total, seoItems.length],
+    [content.data?.total, headers.data?.total, locations.data?.total, pages.data?.total, seo.data?.total, seoRecordsQuery.data?.total, seoItems.length],
   );
 
   const filtered = useMemo(() => {
@@ -136,9 +138,9 @@ export function AdminPanel({ onLogout }: { onLogout: () => void }) {
       };
 
       if (editingId) {
-        await updateContent.mutateAsync({ id: editingId, payload });
+        await updateContentRecord.mutateAsync({ id: editingId, payload });
       } else {
-        await createContent.mutateAsync(payload);
+        await createContentRecord.mutateAsync(payload);
       }
 
       setForm(initialForm);
@@ -162,48 +164,48 @@ export function AdminPanel({ onLogout }: { onLogout: () => void }) {
 
 
   useEffect(() => {
-    const existing = seoItems.find((item) => item.path === seoForm.path);
+    const existing = seoItems.find((item) => item.path === seoFormState.path);
     if (!existing) {
-      setEditingSeoId(null);
+      setEditingSeoRecordId(null);
       return;
     }
 
-    setEditingSeoId(existing.id);
-    setSeoForm((prev) => ({
+    setEditingSeoRecordId(existing.id);
+    setSeoFormState((prev) => ({
       ...prev,
       title: existing.title,
       description: existing.description,
       keywords: existing.keywords,
     }));
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [seoForm.path, seoAll.data?.items, seo.data?.items]);
+  }, [seoFormState.path, seoRecordsQuery.data?.items, seo.data?.items]);
 
   const submitSeo = async (event: FormEvent) => {
     event.preventDefault();
-    setSeoError("");
+    setSeoFormError("");
 
     try {
       const payload = {
-        path: seoForm.path,
-        title: seoForm.title,
-        description: seoForm.description,
-        keywords: seoForm.keywords,
+        path: seoFormState.path,
+        title: seoFormState.title,
+        description: seoFormState.description,
+        keywords: seoFormState.keywords,
         extra_meta_json: {},
       };
 
-      if (editingSeoId) {
-        await updateSeo.mutateAsync({ id: editingSeoId, payload });
+      if (editingSeoRecordId) {
+        await updateSeoRecord.mutateAsync({ id: editingSeoRecordId, payload });
       } else {
-        await upsertSeo.mutateAsync(payload);
+        await createSeoRecord.mutateAsync(payload);
       }
     } catch {
-      setSeoError("Unable to save SEO record. Please check inputs.");
+      setSeoFormError("Unable to save SEO record. Please check inputs.");
     }
   };
 
   const onEditSeo = (record: SeoRecord) => {
-    setEditingSeoId(record.id);
-    setSeoForm({
+    setEditingSeoRecordId(record.id);
+    setSeoFormState({
       path: record.path,
       title: record.title,
       description: record.description,
@@ -254,31 +256,35 @@ export function AdminPanel({ onLogout }: { onLogout: () => void }) {
             <>
               <form onSubmit={submitSeo} className="space-y-3 rounded-lg border p-4">
                 <h3 className="font-semibold">Update SEO (All Pages)</h3>
-                <select className="w-full rounded border px-3 py-2" value={seoForm.path} onChange={(e) => setSeoForm((prev) => ({ ...prev, path: e.target.value, title: "", description: "", keywords: "" }))}>
+                <select className="w-full rounded border px-3 py-2" value={seoFormState.path} onChange={(e) => setSeoFormState((prev) => ({ ...prev, path: e.target.value, title: "", description: "", keywords: "" }))}>
                   {seoPaths.map((path) => (
                     <option key={path} value={path}>
                       {path}
                     </option>
                   ))}
                 </select>
-                <input className="w-full rounded border px-3 py-2" placeholder="Meta title" value={seoForm.title} onChange={(e) => setSeoForm((prev) => ({ ...prev, title: e.target.value }))} />
-                <textarea className="min-h-20 w-full rounded border px-3 py-2" placeholder="Meta description" value={seoForm.description} onChange={(e) => setSeoForm((prev) => ({ ...prev, description: e.target.value }))} />
-                <input className="w-full rounded border px-3 py-2" placeholder="Meta keywords (comma separated)" value={seoForm.keywords} onChange={(e) => setSeoForm((prev) => ({ ...prev, keywords: e.target.value }))} />
-                {seoError ? <p className="text-sm text-red-600">{seoError}</p> : null}
-                <button className="rounded bg-slate-900 px-4 py-2 text-white" type="submit">{editingSeoId ? "Update SEO" : "Save SEO"}</button>
+                <input className="w-full rounded border px-3 py-2" placeholder="Meta title" value={seoFormState.title} onChange={(e) => setSeoFormState((prev) => ({ ...prev, title: e.target.value }))} />
+                <textarea className="min-h-20 w-full rounded border px-3 py-2" placeholder="Meta description" value={seoFormState.description} onChange={(e) => setSeoFormState((prev) => ({ ...prev, description: e.target.value }))} />
+                <input className="w-full rounded border px-3 py-2" placeholder="Meta keywords (comma separated)" value={seoFormState.keywords} onChange={(e) => setSeoFormState((prev) => ({ ...prev, keywords: e.target.value }))} />
+                {seoFormError ? <p className="text-sm text-red-600">{seoFormError}</p> : null}
+                <button className="rounded bg-slate-900 px-4 py-2 text-white" type="submit">{editingSeoRecordId ? "Update SEO" : "Save SEO"}</button>
               </form>
 
               <div>
                 <h3 className="mb-2 font-semibold">SEO records</h3>
-                {seoItems.length === 0 ? (
-                  <p className="text-sm text-muted-foreground">No SEO records found in API response. Click Save SEO to create one for the selected path.</p>
+                {seoLoading ? (
+                  <p className="text-sm text-muted-foreground">Loading SEO records from MySQL…</p>
+                ) : seoLoadError ? (
+                  <p className="text-sm text-red-600">Failed to load SEO records from API: {seoLoadError}</p>
+                ) : seoItems.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">No SEO records found in MySQL `seo_records` table for the current query.</p>
                 ) : (
                   <div className="space-y-2">
                     {seoItems.map((item) => (
                       <div key={item.id} className="rounded border p-3">
                         <div className="mb-2 flex gap-2">
                           <button className="rounded border px-2 py-1 text-xs" onClick={() => onEditSeo(item)}>Edit</button>
-                          <button className="rounded border border-red-200 px-2 py-1 text-xs text-red-600" onClick={() => deleteSeo.mutate(item.id)}>Delete</button>
+                          <button className="rounded border border-red-200 px-2 py-1 text-xs text-red-600" onClick={() => deleteSeoRecord.mutate(item.id)}>Delete</button>
                         </div>
                         <div className="mb-2 grid gap-1 text-xs">
                           <p><span className="font-medium">ID:</span> {item.id}</p>
@@ -327,7 +333,7 @@ export function AdminPanel({ onLogout }: { onLogout: () => void }) {
                       <div key={item.id} className="rounded border p-3">
                         <div className="mb-2 flex gap-2">
                           <button className="rounded border px-2 py-1 text-xs" onClick={() => onEditContent(item)}>Edit</button>
-                          <button className="rounded border border-red-200 px-2 py-1 text-xs text-red-600" onClick={() => deleteContent.mutate(item.id)}>Delete</button>
+                          <button className="rounded border border-red-200 px-2 py-1 text-xs text-red-600" onClick={() => deleteContentRecord.mutate(item.id)}>Delete</button>
                         </div>
                         <div className="mb-2 grid gap-1 text-xs">
                           <p><span className="font-medium">ID:</span> {item.id}</p>

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,19 @@
 {
   "images": {
-    "sizes": [640, 750, 828, 1080, 1200],
-    "domains": ["localhost"],
-    "formats": ["image/avif", "image/webp"],
+    "sizes": [
+      640,
+      750,
+      828,
+      1080,
+      1200
+    ],
+    "domains": [
+      "localhost"
+    ],
+    "formats": [
+      "image/avif",
+      "image/webp"
+    ],
     "minimumCacheTTL": 60
   },
   "build": {
@@ -32,7 +43,7 @@
   ],
   "rewrites": [
     {
-      "source": "/(.*)",
+      "source": "/(?!api/)(.*)",
       "destination": "/index.html"
     }
   ]


### PR DESCRIPTION
### Motivation
- Provide a persistent MySQL-backed CRUD API for managing SEO metadata and surface those records in the admin UI. 
- Make the frontend API base robust for relative deployments by removing a fixed localhost default and trimming trailing slashes. 
- Prevent the SPA rewrite from intercepting `api/` requests on Vercel.

### Description
- Add a MySQL helper at `api/_lib/mysql.js` exporting a connection `pool` and `parseJsonField` utility for safe JSON parsing. 
- Implement a new SEO REST API at `api/v1/seo.js` for listing and creating/upserting records and `api/v1/seo/[id].js` for updating and deleting individual records, including JSON handling and basic validation. 
- Update the client base in `src/api/client.ts` to use a relative default `API_BASE` and remove trailing slashes via `.replace(/\/$/, "")`. 
- Integrate the new API into the admin panel (`src/pages/admin/AdminPanel.tsx`) by renaming state and hooks for clarity, wiring `useQuery` to fetch MySQL SEO records, adding loading/error UI states, and switching CRUD calls to the new record-named hooks. 
- Adjust delete and create/update call sites in the admin UI to use the renamed hooks and improved state variables. 
- Update `vercel.json` to exclude `api/` from the SPA rewrite (`"source": "/(?!api/)(.*)"`) and reformat some JSON fields.

### Testing
- No automated tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d38ec86cdc83339c5e40a202b0a808)